### PR TITLE
Update cleantalk-api.conf

### DIFF
--- a/etc/nginx/snippets/cleantalk-api.conf
+++ b/etc/nginx/snippets/cleantalk-api.conf
@@ -7,4 +7,5 @@ location /spam_check {
 	proxy_cache_valid any 10m;
 	proxy_cache_valid 404 500 501 502 503 1m;
 	proxy_pass https://api.cleantalk.org/;
+	proxy_set_header Cookie ""; 
 }


### PR DESCRIPTION
Your server doesn't like huge `Cookie`, which our website has to handle, but results in 400 HTTP error when contacting the API (too large header). I don't think it makes any sense to pass the Cookie to the API, so best is just strip it away? Solved the 400 for us.